### PR TITLE
Fix for Bittle X voice intialization on boot

### DIFF
--- a/src/io.h
+++ b/src/io.h
@@ -11,7 +11,10 @@
 template<typename T>
 void printToAllPorts(T text, bool newLine = true) {
   String textResponse = String(text);
-
+  
+// Motion-completion handshake for the Xiaozhi AI dialogue module: it commands a motion and
+// needs to know when the robot has finished. It matches on the bare token, which is why
+// there is deliberately no terminator here.
 #ifndef XIAOZHI_COMPLETION_ECHO
 #define XIAOZHI_COMPLETION_ECHO 1
 #endif

--- a/src/io.h
+++ b/src/io.h
@@ -11,12 +11,16 @@
 template<typename T>
 void printToAllPorts(T text, bool newLine = true) {
   String textResponse = String(text);
-  // Echo motion completion tokens to Xiaozhi voice UART before appending newline,
-  // otherwise "k"/"m" become "k\r\n"/"m\r\n" and the match never succeeds.
-  if (moduleActivatedQ[1] && (textResponse == "k" || textResponse == "m")) {
-    SERIAL_VOICE.write((uint8_t)textResponse.charAt(0));
-    SERIAL_VOICE.flush();
+
+#ifndef XIAOZHI_COMPLETION_ECHO
+#define XIAOZHI_COMPLETION_ECHO 1
+#endif
+#if XIAOZHI_COMPLETION_ECHO
+  if (moduleActivatedQ[0] && (textResponse == "k" || textResponse == "m")) {
+    Serial2.write((uint8_t)textResponse.charAt(0));
+    Serial2.flush();
   }
+#endif
 
   if (newLine) {
     textResponse += "\r\n";


### PR DESCRIPTION
On V1.0 Bittle X current firmware delivers unframed bytes into the VOICE COMMAND module's line-based channel, where each one prefixes the next command and makes it fail: XAc becomes kXAc and is dropped. B10_251121 predates the echo and needed no arming sequence at all.

The reason is that f93cdbf, 2026-07-17 writes this to SERIAL_VOICE, gated on moduleActivatedQ[1] -- the VOICE module. That was correct when written: on BiBoard V0.1/V0.2, SERIAL_VOICE is Serial2, the Grove UART the AI module sits on. BiBoard V1.0 split them -- voice moved to Serial1 (RX26/TX25), Grove stayed on Serial2 (RX9/TX10) -- and this line was never updated. 
Fixed by addressing rather than by switching off, because the feature is wanted: Serial2 is the Grove/AI UART on every board revision, and moduleActivatedQ[0] is Grove_Serial. So this is right on V0.x and V1.0 alike, and Xiaozhi keeps working on both.