### PR TITLE
Update Quaddle Kickstarter messaging and README readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCatESP32 — OpenCat Framework on ESP32/BiBoard
 
-🚀 **[Quaddle](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-hero-banner) — Petoi's newest OpenCat-lineage quadruped — launches on Kickstarter August 2026.** [Reserve your spot →](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-hero-banner) (details below)
+🚀 **[Quaddle](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_hero-banner&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-hero-banner) — Petoi's newest OpenCat-lineage quadruped — goes live on Kickstarter Sept 2, 2026.** [Get notified →](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_hero-banner&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-hero-banner) (details below)
 
 OpenCatESP32 runs the OpenCat quadruped robotics framework on [BiBoard](https://www.petoi.com/products/biboard-esp32-development-board-for-quadruped-robot?utm_source=github&utm_medium=code&utm_campaign=github-opencat) — an ESP32-based development board designed for multi-degree-of-freedom legged robots with up to 12 servos. Developed by [Petoi](https://www.petoi.com?utm_source=github&utm_medium=code&utm_campaign=github-opencat), the maker of futuristic programmable robotic pets.
 
@@ -14,12 +14,22 @@ This is the codebase for current-generation Petoi hardware. If you're on the old
 
 ---
 
-## Coming Soon: Quaddle mini robot dog
+## Quaddle mini robot dog — launching on Kickstarter Sept 2, 2026
 ![](https://github.com/PetoiCamp/NonCodeFiles/blob/master/gif/quaddleCover.gif?raw=true)
 
-[Quaddle](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-quaddle-section) is Petoi's newest quadruped, launching on Kickstarter **August 2026** — a mini desk robot built on the same OpenCat lineage as Bittle and Nybble. What makes it worth a look: it's a full quadruped running on just 4 servos instead of the usual 8–12, which forces genuinely different gait-design and leg-coordination solutions to still get all four legs walking, running, and balancing. Its servos are also position-feedback — readable, not just drivable — which is what makes Puppet Mode possible: hand-guide the legs and record a motion directly, no code required to capture a new behavior. We'll also share 3D-printable shells and mounts for customization. Same open platform this repo already supports for gait research, RL, and sim2real work — a hands-on physical AI platform, not a toy version of the idea.
+[Quaddle](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_quaddle-section&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-quaddle-section) is Petoi's newest quadruped, **going live on Kickstarter Sept 2, 2026** — a mini desk robot built on the same OpenCat lineage as Bittle and Nybble.
 
-**Source code is not yet public.** It's an upgraded version of the OpenCat project, and its ESP32-S3 code structure is closer to this repo than to the main NyBoard-based [OpenCat repo](https://github.com/PetoiCamp/OpenCat-Quadruped-Robot). We plan to open source it before Quaddle delivery. Watch this repo and [r/petoi](https://www.reddit.com/r/Petoi/) for the announcement, or [reserve a spot](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-reserve-spot-link) to get notified at launch.
+- Full quadruped running on just **4 servos** instead of the usual 8–12, which forces genuinely different gait-design and leg-coordination solutions to still get all four legs walking, running, and balancing
+- Position-feedback servos — readable, not just drivable — which is what makes **Puppet Mode** possible: hand-guide the legs and record a motion directly, no code required
+- 3D-printable shells and mounts for customization
+- Same open platform this repo already supports for gait research, reinforcement learning (RL), and sim2real work — a hands-on physical AI platform, not a toy version of the idea
+- Try it in the [online simulator](https://www.petoi.com/pages/quaddle-robot-dog-simulator?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-quaddle-simulator) before it ships
+
+**Source code is not yet public.** It's an upgraded version of the OpenCat project, and its ESP32-S3 code structure is closer to this repo than to the main NyBoard-based [OpenCat repo](https://github.com/PetoiCamp/OpenCat-Quadruped-Robot). We plan to open source it before Quaddle delivery.
+
+- Watch this repo and [r/petoi](https://www.reddit.com/r/Petoi/) for the open-source announcement
+- [Get notified on Kickstarter](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_notify-link&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-notify-link) when it goes live
+- Check out the [Quaddle Hugging Face page](https://huggingface.co/petoi/quaddle)
 
 ---
 
@@ -40,7 +50,9 @@ Since then:
 
 BiBoard is the control board for:
 
-- 🐶 [Bittle X — mini robot dog & AI robotics kit with voice control](https://www.petoi.com/products/petoi-robot-dog-bittle-x-voice-controlled?utm_source=github&utm_medium=code&utm_campaign=github-opencat) · [buy on Amazon](https://www.amazon.com/dp/B0FNT6TSVT?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-amazon-buy-link)
+- 🐶 [Bittle X — mini robot dog & AI robotics kit with voice control](https://www.petoi.com/products/petoi-robot-dog-bittle-x-voice-controlled?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
+  - [Also available on Amazon](https://www.amazon.com/dp/B0FNT6TSVT?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-amazon-buy-link)
+  - [Try the simulator](https://www.petoi.com/pages/bittle-x-robot-dog-simulator?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-bittle-x-simulator)
 - 🐱 [Nybble Q — mini robot cat & AI robotics kit](https://www.petoi.com/products/petoi-nybble-q-robot-cat?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
 
 The older [Bittle](https://www.petoi.com/collections/robots/products/petoi-bittle-robot-dog?utm_source=github&utm_medium=code&utm_campaign=github-opencat) and [Nybble](https://www.petoi.com/collections/robots/products/petoi-nybble-robot-cat?utm_source=github&utm_medium=code&utm_campaign=github-opencat) (NyBoard) are discontinued. BiBoard is the current platform.
@@ -86,8 +98,7 @@ Full setup: [Upload Sketch for BiBoard](https://guide.petoi.com/arduino-ide/uplo
 - [Raspberry Pi robotics projects](https://www.petoi.com/blogs/blog/tagged/raspberry-pi?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
 - [NVIDIA Isaac simulations and reinforcement learning](https://www.youtube.com/playlist?list=PLHMFXft_rV6MWNGyofDzRhpatxZuUZMdg)
 - [SLAM with ROS using Bittle and Raspberry Pi](https://www.youtube.com/watch?v=uXpQUIF_Jyk&list=PLHMFXft_rV6MWNGyofDzRhpatxZuUZMdg&index=6)
-
-Academic and research use: [Research Spotlight](https://www.petoi.com/pages/robotics-research-and-academic-applications?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
+- [Research Spotlight](https://www.petoi.com/pages/robotics-research-and-academic-applications?utm_source=github&utm_medium=code&utm_campaign=github-opencat) — academic and research use
 
 ---
 
@@ -104,7 +115,9 @@ OpenCat shows up in **AI robotics education** across K-12 programs, community co
 ## Community & Discussion
 
 - [r/OpenCat](https://www.reddit.com/r/OpenCat/) — firmware code, framework hacking, extending and porting OpenCat
-- [r/Petoi](https://www.reddit.com/r/Petoi/) — hardware Q&A, builds, quadruped coding, curriculum, 3D-printed parts, general discussion
+- [r/Petoi](https://www.reddit.com/r/Petoi/) — hardware Q&A, builds, quadruped coding, RL experiments, curriculum, 3D-printed parts, general discussion
+- [Facebook Group](https://www.facebook.com/groups/385050523510952) — community discussion and builds
+- [Discord](https://discord.com/invite/ckdu23q8nr) — real-time chat with the Petoi community
 
 ---
 
@@ -118,4 +131,11 @@ OpenCat shows up in **AI robotics education** across K-12 programs, community co
 - [All kits and accessories](https://www.petoi.com/store?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
 - [FAQ](https://www.petoi.com/pages/faq?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
 
-Follow the project: [YouTube](https://www.youtube.com/@petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-youtube-follow) · [Twitter](https://twitter.com/petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-twitter-follow) · [Instagram](https://www.instagram.com/petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-instagram-follow) · [Facebook](https://www.facebook.com/PetoiCamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-facebook-follow) · [LinkedIn](https://www.linkedin.com/company/petoi/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-linkedin-follow)
+Follow the project:
+
+- [YouTube](https://www.youtube.com/@petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-youtube-follow)
+- [Twitter](https://twitter.com/petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-twitter-follow)
+- [Instagram](https://www.instagram.com/petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-instagram-follow)
+- [Facebook](https://www.facebook.com/PetoiCamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-facebook-follow)
+- [LinkedIn](https://www.linkedin.com/company/petoi/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-linkedin-follow)
+- [TikTok](https://www.tiktok.com/@petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-tiktok-follow)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is the codebase for current-generation Petoi hardware. If you're on the old
 
 **Source code is not yet public.** It's an upgraded version of the OpenCat project, and its ESP32-S3 code structure is closer to this repo than to the main NyBoard-based [OpenCat repo](https://github.com/PetoiCamp/OpenCat-Quadruped-Robot). We plan to open source it before Quaddle delivery.
 
-- Watch this repo and [r/petoi](https://www.reddit.com/r/Petoi/) for the open-source announcement
+- Watch this repo, [r/petoi](https://www.reddit.com/r/Petoi/), and [Discord](https://discord.com/invite/ckdu23q8nr) for the open-source announcement
 - [Get notified on Kickstarter](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_notify-link&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=esp32-readme-notify-link) when it goes live
 - Check out the [Quaddle Hugging Face page](https://huggingface.co/petoi/quaddle)
 


### PR DESCRIPTION
## Summary
- Point Quaddle links to the live Kickstarter campaign (Sept 2, 2026) instead of the prelaunch page, add Hugging Face and simulator links
- Restructure dense Quaddle/Hardware/Resources sections into bullet lists for readability
- Add Discord, Facebook Group, and TikTok links alongside existing community/social links

## Test plan
- [x] Verified no leftover prelaunch/reserve/August 2026 references remain
- [ ] Preview rendered README on GitHub